### PR TITLE
Check for existing name in publishName

### DIFF
--- a/PSync/full-producer-arbitrary.cpp
+++ b/PSync/full-producer-arbitrary.cpp
@@ -71,6 +71,11 @@ FullProducerArbitrary::~FullProducerArbitrary()
 void
 FullProducerArbitrary::publishName(const ndn::Name& name)
 {
+  if (m_name2hash.find(name) != m_name2hash.end()) {
+    NDN_LOG_DEBUG("Already published, ignoring: " << name);
+    return;
+  }
+
   NDN_LOG_INFO("Publish: " << name);
 
   insertToIBF(name);

--- a/PSync/full-producer-arbitrary.hpp
+++ b/PSync/full-producer-arbitrary.hpp
@@ -99,13 +99,7 @@ public:
   /**
    * @brief Publish name to let others know
    *
-   * addUserNode needs to be called before this to add the prefix
-   * if not already added via the constructor.
-   * If seq is null then the seq of prefix is incremented by 1 else
-   * the supplied sequence is set in the IBF.
-   *
-   * @param prefix the prefix to be updated
-   * @param seq the sequence number of the prefix
+   * @param name the Name to be updated
    */
   void
   publishName(const ndn::Name& name);

--- a/PSync/full-producer-arbitrary.hpp
+++ b/PSync/full-producer-arbitrary.hpp
@@ -99,6 +99,7 @@ public:
   /**
    * @brief Publish name to let others know
    *
+   * However, if the name has already been published, do nothing.
    * @param name the Name to be updated
    */
   void


### PR DESCRIPTION
We can't insert the same name twice to the IBLT, so check before inserting.